### PR TITLE
GH actions index with scip-go

### DIFF
--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -4,7 +4,7 @@ on:
 jobs:
   lsif-go:
     runs-on: ubuntu-latest
-    container: sourcegraph/lsif-go
+    container: sourcegraph/scip-go
     steps:
       - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # tag=v3
       - name: Generate LSIF data


### PR DESCRIPTION
Replace lsif code intel builds with scip in github actions

[_Created by Sourcegraph batch change `christine/GithubActions-updateSGTest`._](https://demo.sourcegraph.com/users/christine/batch-changes/GithubActions-updateSGTest)